### PR TITLE
[IMP] scrummer_scrum: Correct sprint length and timezone in sprint start and end date

### DIFF
--- a/scrummer_scrum/controllers/main.py
+++ b/scrummer_scrum/controllers/main.py
@@ -27,7 +27,7 @@ class ScrummerController(main.ScrummerController):
     @http.route([
         '/scrummer/web/data/sprint'
         '/<model("project.agile.scrum.sprint"):sprint>/stop',
-        ], type='json', auth='user')
+    ], type='json', auth='user')
     def sprint_stop(self, sprint):
         # Mark sprint as done
         sprint.write({
@@ -109,7 +109,7 @@ class ScrummerController(main.ScrummerController):
 
         for project in board.project_ids:
             if not project_id or project_id and project_id == project.id:
-                board_data['board']['projects'][project.id] =\
+                board_data['board']['projects'][project.id] = \
                     self.prepare_project(project)
 
         active_sprint = request.env.user.team_id.active_sprint_id
@@ -133,8 +133,9 @@ class ScrummerController(main.ScrummerController):
             board_data['ids'] = tasks_in_board.ids
         return board_data
 
-    def _prepare_sprint_task_filter(self, active_sprint, board_data,
-                                    stages_in_board, board):
+    def _prepare_sprint_task_filter(
+            self, active_sprint, board_data,
+            stages_in_board, board):
         task_filter = [
             ('sprint_id', '=', active_sprint.id),
             ('stage_id', 'in', stages_in_board),
@@ -163,7 +164,10 @@ class ScrummerController(main.ScrummerController):
 
     def prepare_user_team(self, team):
         result = super(ScrummerController, self).prepare_user_team(team)
-        result["sprint_ids"] = team.sprint_ids.filtered(
-            lambda x: x.state != "completed"
-        ).ids
+        result.update({
+            "sprint_ids": team.sprint_ids.filtered(
+                lambda x: x.state != "completed"
+            ).ids,
+            "default_sprint_length": int(team.default_sprint_length)
+        })
         return result

--- a/scrummer_scrum/models/project_agile_team.py
+++ b/scrummer_scrum/models/project_agile_team.py
@@ -62,7 +62,8 @@ class ScrumTeam(models.Model):
         ],
         string='Default sprint length',
         default='2',
-        help="Default Sprint time for this project"
+        help="Default Sprint time for this project",
+        scrummer=True,
     )
 
     @api.multi

--- a/scrummer_scrum/static/src/js/views/backlog.js
+++ b/scrummer_scrum/static/src/js/views/backlog.js
@@ -74,13 +74,13 @@ odoo.define('scrummer_scrum.view.backlog', function (require) {
             };
         },
         start_date_f() {
-            return this._model.start_date;
+            return moment(moment.utc(this._model.start_date, "YYYY-MM-DD HH:mm:SS").toDate()).format("LLL");
             // var formatted = field_utils.format['datetime'](this._model.start_date);
             // return formatted;
         },
 
         end_date_f() {
-            return this._model.end_date;
+            return moment(moment.utc(this._model.end_date, "YYYY-MM-DD HH:mm:SS").toDate()).format("LLL")
             // var formatted = field_utils.format['datetime'](this._model.end_date);
             // return formatted;
         },
@@ -531,11 +531,11 @@ odoo.define('scrummer_scrum.view.backlog', function (require) {
         _onStartSprint(evt) {
             const sprint = evt.data.sprint;
             dialog.confirm(_t("Start sprint"), _t("Are you sure you want to start this sprint?"), _t("yes")).done(() => {
-                let start_date = moment(new Date()).hours(9).minutes(0).seconds(0);
+                let start_date = moment().hours(9).minutes(0).seconds(0);
 
                 // When loading backlog view we need to load team details as well.
-                // TODO: Here we need to take actual sprint length setting from team level.
-                let end_date = start_date.clone().add(2, 'week');
+                const sprint_length = this.user.team_ids[this.user.team_id[0]].default_sprint_length;
+                let end_date = start_date.clone().add(sprint_length, 'week');
 
                 start_date = field_utils.parse.datetime(start_date); //, {timezone: false}
                 end_date = field_utils.parse.datetime(end_date); //, {timezone: false})


### PR DESCRIPTION
Starting sprint will set end date according to specified sprint length on team.
Time fields on sprint are shown according to timezone as they are shown in Odoo web.